### PR TITLE
サンプル実行時オプション引数の環境変数による指定を可能にする

### DIFF
--- a/recvonly/recvonly.py
+++ b/recvonly/recvonly.py
@@ -1,8 +1,8 @@
 import argparse
 import json
+import os
 import queue
 import signal
-import time
 
 import cv2
 import sounddevice
@@ -96,12 +96,14 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
     # 必須引数
-    parser.add_argument("--signaling-url", required=True, help="シグナリング URL")
-    parser.add_argument("--channel-id", required=True, help="チャネルID")
+    signaling_url = os.getenv("SIGNALING_URL")
+    parser.add_argument("--signaling-url", default=signaling_url, required=not signaling_url, help="シグナリング URL")
+    channel_id = os.getenv("CHANNEL_ID")
+    parser.add_argument("--channel-id", default=channel_id, required=not channel_id, help="チャネルID")
 
     # オプション引数
-    parser.add_argument("--client_id", default='',  help="クライアントID")
-    parser.add_argument("--metadata", help="メタデータ JSON")
+    parser.add_argument("--client-id", default=os.getenv("CLIENT_ID", ""),  help="クライアントID")
+    parser.add_argument("--metadata", default=os.getenv("METADATA"), help="メタデータ JSON")
     args = parser.parse_args()
 
     metadata = None
@@ -109,5 +111,5 @@ if __name__ == '__main__':
         metadata = json.loads(args.metadata)
 
     recvonly = Recvonly(args.signaling_url, args.channel_id,
-                        args.client_id, args.metadata)
+                        args.client_id, metadata)
     recvonly.run()

--- a/sendonly/sendonly.py
+++ b/sendonly/sendonly.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 import signal
 
 import cv2
@@ -64,13 +65,15 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
     # 必須引数
-    parser.add_argument("--signaling-url", required=True, help="シグナリング URL")
-    parser.add_argument("--channel-id", required=True, help="チャネルID")
+    signaling_url = os.getenv("SIGNALING_URL")
+    parser.add_argument("--signaling-url", default=signaling_url, required=not signaling_url, help="シグナリング URL")
+    channel_id = os.getenv("CHANNEL_ID")
+    parser.add_argument("--channel-id", default=channel_id, required=not channel_id, help="チャネルID")
 
     # オプション引数
-    parser.add_argument("--client_id", default='',  help="クライアントID")
-    parser.add_argument("--metadata", help="メタデータ JSON")
-    parser.add_argument("--camera-id", type=int, default=0, help="cv2.VideoCapture() に渡すカメラ ID")
+    parser.add_argument("--client-id", default=os.getenv("CLIENT_ID", ""),  help="クライアントID")
+    parser.add_argument("--metadata", default=os.getenv("METADATA"), help="メタデータ JSON")
+    parser.add_argument("--camera-id", type=int, default=int(os.getenv("CAMERA_ID", "0")), help="cv2.VideoCapture() に渡すカメラ ID")
     args = parser.parse_args()
 
     metadata = None
@@ -78,5 +81,5 @@ if __name__ == '__main__':
         metadata = json.loads(args.metadata)
 
     sendonly = SendOnly(args.signaling_url, args.channel_id,
-                        args.client_id, args.metadata, args.camera_id)
+                        args.client_id, metadata, args.camera_id)
     sendonly.run()


### PR DESCRIPTION
```bash
SIGNALING_URL=<signaling_url> \
  CHANNEL_ID=<channel_id> \
  METADATA='<metadata-json>' \
  rye run python recvonly/recvonly.py
```

にて動作することを確認済みです。
sendonly/sendonly.py も同様に確認済みです。