### PR TITLE
オプション --metadata の指定なしで実行するとエラーが発生する問題を修正

### DIFF
--- a/recvonly/recvonly.py
+++ b/recvonly/recvonly.py
@@ -107,7 +107,7 @@ if __name__ == '__main__':
     parser.add_argument("--metadata", default=os.getenv("SORA_METADATA"), help="メタデータ JSON")
     args = parser.parse_args()
 
-    metadata = None
+    metadata = {}
     if args.metadata:
         metadata = json.loads(args.metadata)
 

--- a/sendonly/sendonly.py
+++ b/sendonly/sendonly.py
@@ -77,7 +77,7 @@ if __name__ == '__main__':
     parser.add_argument("--camera-id", type=int, default=int(os.getenv("SORA_CAMERA_ID", "0")), help="cv2.VideoCapture() に渡すカメラ ID")
     args = parser.parse_args()
 
-    metadata = None
+    metadata = {}
     if args.metadata:
         metadata = json.loads(args.metadata)
 


### PR DESCRIPTION
sora sdk に metadata = None を渡すことができないため、辞書型で初期化します。